### PR TITLE
Add travis-ci tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,17 @@
+sudo: false
+language: python
+python:
+  - "3.2"
+  - "3.3"
+  - "3.4"
+  - "3.5"
+
+os:
+    - linux
+
+install:
+  - pip install .
+  - pip install -r requirements.txt
+
+script:
+    - bash run_unittests.sh

--- a/suites/testGame.py
+++ b/suites/testGame.py
@@ -3,12 +3,9 @@ from argparse import Namespace
 
 from gamebot.game import BaseGame
 from gamebot.game.player import BasePlayer
-from gamebot.game.team import BaseTeam
+from gamebot.game.instance import BaseInstance
 
 from gamebot.coup.exceptions import GameInvalidOperation, GamePermissionError
-
-from suites.testPlayer import TestTeam
-
 
 base_parameters = {'name': 'testgame',
                    'password': 'pass'}
@@ -20,7 +17,7 @@ args = Namespace(**base_parameters)
 
 class BaseGameTester(unittest.TestCase):
     def test_create(self):
-        instance = 'x'
+        instance = BaseInstance()
         game = BaseGame(instance, default_user, default_players, args)
 
         self.assertTrue(game.game_creator == default_user)
@@ -28,7 +25,7 @@ class BaseGameTester(unittest.TestCase):
         self.assertTrue(game.password == args.password)
 
     def test_add_player(self):
-        instance = 'x'
+        instance = BaseInstance()
         game = BaseGame(instance, default_user, default_players, args)
 
         player = BasePlayer(default_user)


### PR DESCRIPTION
Added .travis.yml to the repository and enabled testing for python 3.2, 3.3, 3.4 and 3.5 on linux.